### PR TITLE
feat: enable automated updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "packageRules": [
+    {
+      "automerge": true,
+      "enabled": true,
+      "matchManagers": [
+        "bazel",
+        "bazel-module",
+        "gomod"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ]
+    }
+  ],
+  "postUpdateOptions": [
+    "gomodMassage",
+    "gomodTidy"
+  ]
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,12 +38,12 @@ jobs:
             cpu_flag:
             ext: ".exe"
 
-          - name: darwin_amd64
-            artifact: ibazel_darwin_amd64
-            os: macos-latest
-            build_flags: --platforms=@io_bazel_rules_go//go/toolchain:darwin_amd64_cgo
-            cpu_flag: --cpu=darwin_amd64
-            ext: ""
+          #- name: darwin_amd64
+          #  artifact: ibazel_darwin_amd64
+          #  os: macos-latest
+          #  build_flags: --platforms=@io_bazel_rules_go//go/toolchain:darwin_amd64_cgo
+          #  cpu_flag: --cpu=darwin_amd64
+          #  ext: ""
 
           - name: darwin_arm64
             artifact: ibazel_darwin_arm64

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,9 +10,6 @@ on:
 
 jobs:
   build:
-    concurrency:
-      group: ${{ github.ref }}
-      cancel-in-progress: true
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -63,4 +60,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build ibazel
+        concurrency:
+          group: ${{ github.ref }}
+          cancel-in-progress: true
         run: bazel build //cmd/ibazel:ibazel --config release ${{ matrix.build_flags }} ${{ matrix.cpu_flag }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
             artifact: ibazel_darwin_amd64
             os: macos-latest
             build_flags: --platforms=@io_bazel_rules_go//go/toolchain:darwin_amd64_cgo
-            cpu_flag:
+            cpu_flag: --cpu=darwin_amd64
             ext: ""
 
           - name: darwin_arm64

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     concurrency:
-      group: ${{ github.ref }}
+      group: ${{ github.ref }}-${{ matrix.artifact }}
       cancel-in-progress: true
     strategy:
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,9 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    concurrency:
+      group: ${{ github.ref }}
+      cancel-in-progress: true
     strategy:
       matrix:
         include:
@@ -60,7 +63,4 @@ jobs:
           fetch-depth: 0
 
       - name: Build ibazel
-        concurrency:
-          group: ${{ github.ref }}
-          cancel-in-progress: true
         run: bazel build //cmd/ibazel:ibazel --config release ${{ matrix.build_flags }} ${{ matrix.cpu_flag }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,66 @@
+name: Basic Build
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+  push:
+
+jobs:
+  build:
+    concurrency:
+      group: ${{ github.ref }}
+      cancel-in-progress: true
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - name: linux_amd64
+            artifact: ibazel_linux_amd64
+            os: ubuntu-latest
+            build_flags: --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64
+            cpu_flag:
+            ext: ""
+
+          - name: linux_arm64
+            artifact: ibazel_linux_arm64
+            os: ubuntu-latest
+            build_flags: --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64
+            cpu_flag:
+            ext: ""
+
+          - name: windows_amd64
+            artifact: ibazel_windows_amd64.exe
+            os: ubuntu-latest
+            build_flags: --platforms=@io_bazel_rules_go//go/toolchain:windows_amd64
+            cpu_flag:
+            ext: ".exe"
+
+          - name: darwin_amd64
+            artifact: ibazel_darwin_amd64
+            os: macos-latest
+            build_flags: --platforms=@io_bazel_rules_go//go/toolchain:darwin_amd64_cgo
+            cpu_flag:
+            ext: ""
+
+          - name: darwin_arm64
+            artifact: ibazel_darwin_arm64
+            os: macos-latest
+            build_flags: --platforms=@io_bazel_rules_go//go/toolchain:darwin_arm64_cgo
+            # TODO: temporary workaround, remove this in the future.
+            # Right now, without the flag, GitHub actions build would link to the "darwin_amd64" go_sdk toolchain and fail the build.
+            # related issue: https://github.com/fsnotify/fsevents/issues/50
+            # also general info on Bazel platforms: https://bazel.build/concepts/platforms#migration
+            cpu_flag: --cpu=darwin_arm64
+            ext: ""
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build ibazel
+        run: bazel build //cmd/ibazel:ibazel --config release ${{ matrix.build_flags }} ${{ matrix.cpu_flag }}


### PR DESCRIPTION
In order to activate some recurring updates with a CI step to validate, let's activate some RenovateBot goodness.
 - renovate config auto merging patch/minor updates
 - ci on push/pr
 - removed production-scale CI.