### PR TITLE
fix: enable fork-processing to allow renovate on this repo-fork

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,6 +15,7 @@
   "extends": [
     "config:recommended"
   ],
+  "forkProcessing": "enabled",
   "labels": [
     "dependencies"
   ],


### PR DESCRIPTION
https://docs.renovatebot.com/configuration-options/#forkprocessing -- who knew?  :-/

Might still need to move the config file to the repo root.